### PR TITLE
Add raw data support for user-defined custom logic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ public function listThreadMessagesAsRaw(string $remoteThreadId)
 public function updateThreadAsRaw(string $remoteThreadId, array $data) /* $data = ['role' => 'user or assistant', 'content' => 'Hello'] */
 public function deleteThreadAsRaw(string $remoteThreadId)
 public function threadAsRaw(string $threadId)
-public function messageAsRaw($threadId, $messageId)
+public function messageAsRaw(string $threadId, string $messageId)
 public function modifyMessageAsRaw(string $threadId, string $messageId, array $parameters)
 ```
 
@@ -105,7 +105,7 @@ ChatBot::listThreadMessagesAsRaw(string $remoteThreadId);
 ChatBot::updateThreadAsRaw(string $remoteThreadId, array $data);
 ChatBot::deleteThreadAsRaw(string $remoteThreadId);
 ChatBot::threadAsRaw(string $threadId);
-ChatBot::messageAsRaw($threadId, $messageId);
+ChatBot::messageAsRaw(string $threadId, string $messageId);
 ChatBot::modifyMessageAsRaw(string $threadId, string $messageId, array $parameters);
 ```
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,29 @@ ChatBot::updateThread('Hi', $id); /* Continue the conversation */
 ChatBot::deleteThread($id); /* Delete the thread */
 ```
 
+### Raw Data - Not Saved to Database
+#### You can use the following methods to interact with the OpenAI API directly.
+
+```php
+public function createThreadAsRaw(string $subject)
+public function listThreadMessagesAsRaw(string $remoteThreadId)
+public function updateThreadAsRaw(string $remoteThreadId, array $data) /* $data = ['role' => 'user or assistant', 'content' => 'Hello'] */
+public function deleteThreadAsRaw(string $remoteThreadId)
+public function threadAsRaw(string $threadId)
+public function messageAsRaw($threadId, $messageId)
+public function modifyMessageAsRaw(string $threadId, string $messageId, array $parameters)
+```
+
+```php
+ChatBot::createThreadAsRaw(string $subject);
+ChatBot::listThreadMessagesAsRaw(string $remoteThreadId);
+ChatBot::updateThreadAsRaw(string $remoteThreadId, array $data);
+ChatBot::deleteThreadAsRaw(string $remoteThreadId);
+ChatBot::threadAsRaw(string $threadId);
+ChatBot::messageAsRaw($threadId, $messageId);
+ChatBot::modifyMessageAsRaw(string $threadId, string $messageId, array $parameters);
+```
+
 ## Testing
 
 ```bash

--- a/src/ChatBot.php
+++ b/src/ChatBot.php
@@ -3,13 +3,18 @@
 namespace HalilCosdu\ChatBot;
 
 use HalilCosdu\ChatBot\Services\ChatBotService;
+use HalilCosdu\ChatBot\Services\OpenAI\RawService;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use OpenAI\Responses\Threads\Messages\ThreadMessageListResponse;
+use OpenAI\Responses\Threads\Messages\ThreadMessageResponse;
+use OpenAI\Responses\Threads\ThreadDeleteResponse;
+use OpenAI\Responses\Threads\ThreadResponse;
 
 readonly class ChatBot
 {
-    public function __construct(private ChatBotService $chatBotService)
+    public function __construct(private ChatBotService $chatBotService, private RawService $rawService)
     {
         //
     }
@@ -37,5 +42,41 @@ readonly class ChatBot
     public function deleteThread(int $id, mixed $ownerId = null): void
     {
         $this->chatBotService->delete($id, $ownerId);
+    }
+
+    public function createThreadAsRaw(string $subject): ThreadResponse
+    {
+        return $this->rawService->createThreadAsRaw($subject);
+    }
+
+    public function threadAsRaw(string $threadId): ThreadResponse
+    {
+        return $this->rawService->threadAsRaw($threadId);
+    }
+
+    public function messageAsRaw($threadId, $messageId): ThreadMessageResponse
+    {
+        return $this->rawService->messageAsRaw($threadId, $messageId);
+    }
+
+    public function modifyMessageAsRaw(string $threadId, string $messageId, array $parameters): ThreadMessageResponse
+    {
+        return $this->rawService->modifyMessageAsRaw($threadId, $messageId, $parameters);
+    }
+
+    public function listThreadMessagesAsRaw(string $remoteThreadId): ThreadMessageListResponse
+    {
+        return $this->rawService->listThreadMessagesAsRaw($remoteThreadId);
+
+    }
+
+    public function updateThreadAsRaw(string $remoteThreadId, array $data): ThreadResponse
+    {
+        return $this->rawService->updateThreadAsRaw($remoteThreadId, $data);
+    }
+
+    public function deleteThreadAsRaw(string $remoteThreadId): ThreadDeleteResponse
+    {
+        return $this->rawService->deleteThreadAsRaw($remoteThreadId);
     }
 }

--- a/src/Facades/ChatBot.php
+++ b/src/Facades/ChatBot.php
@@ -17,7 +17,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \HalilCosdu\ChatBot\ChatBot updateThreadAsRaw(string $remoteThreadId, array $data)
  * @method static \HalilCosdu\ChatBot\ChatBot deleteThreadAsRaw(string $remoteThreadId)
  * @method static \HalilCosdu\ChatBot\ChatBot threadAsRaw(string $threadId)
- * @method static \HalilCosdu\ChatBot\ChatBot messageAsRaw($threadId, $messageId)
+ * @method static \HalilCosdu\ChatBot\ChatBot messageAsRaw(string $threadId,string $messageId)
  * @method static \HalilCosdu\ChatBot\ChatBot modifyMessageAsRaw(string $threadId, string $messageId, array $parameters)
  */
 class ChatBot extends Facade

--- a/src/Facades/ChatBot.php
+++ b/src/Facades/ChatBot.php
@@ -12,6 +12,13 @@ use Illuminate\Support\Facades\Facade;
  * @method static \HalilCosdu\ChatBot\ChatBot thread(int $id, mixed $ownerId = null)
  * @method static \HalilCosdu\ChatBot\ChatBot updateThread(string $message, int $id, mixed $ownerId = null)
  * @method static \HalilCosdu\ChatBot\ChatBot deleteThread(int $id, mixed $ownerId = null)
+ * @method static \HalilCosdu\ChatBot\ChatBot createThreadAsRaw(string $subject)
+ * @method static \HalilCosdu\ChatBot\ChatBot listThreadMessagesAsRaw(string $remoteThreadId)
+ * @method static \HalilCosdu\ChatBot\ChatBot updateThreadAsRaw(string $remoteThreadId, array $data)
+ * @method static \HalilCosdu\ChatBot\ChatBot deleteThreadAsRaw(string $remoteThreadId)
+ * @method static \HalilCosdu\ChatBot\ChatBot threadAsRaw(string $threadId)
+ * @method static \HalilCosdu\ChatBot\ChatBot messageAsRaw($threadId, $messageId)
+ * @method static \HalilCosdu\ChatBot\ChatBot modifyMessageAsRaw(string $threadId, string $messageId, array $parameters)
  */
 class ChatBot extends Facade
 {

--- a/src/Services/ChatBotService.php
+++ b/src/Services/ChatBotService.php
@@ -3,15 +3,17 @@
 namespace HalilCosdu\ChatBot\Services;
 
 use HalilCosdu\ChatBot\Models\Thread;
+use HalilCosdu\ChatBot\Traits\WaitsForThreadRunCompletion;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
 use OpenAI\Client;
 
 class ChatBotService
 {
+    use WaitsForThreadRunCompletion;
+
     public function __construct(public Client $client)
     {
         //
@@ -114,14 +116,5 @@ class ChatBotService
         $this->client->threads()->delete($thread->remote_thread_id);
 
         $thread->delete();
-    }
-
-    public function waitForThreadRunCompletion($remoteThreadId, $runId): void
-    {
-        do {
-            Sleep::sleep(config('chatbot.sleep_seconds', .1));
-
-            $run = $this->client->threads()->runs()->retrieve($remoteThreadId, $runId);
-        } while ($run->status !== 'completed');
     }
 }

--- a/src/Services/OpenAI/RawService.php
+++ b/src/Services/OpenAI/RawService.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace HalilCosdu\ChatBot\Services\OpenAI;
+
+use HalilCosdu\ChatBot\Traits\WaitsForThreadRunCompletion;
+use OpenAI\Client;
+use OpenAI\Responses\Threads\Messages\ThreadMessageListResponse;
+use OpenAI\Responses\Threads\Messages\ThreadMessageResponse;
+use OpenAI\Responses\Threads\ThreadDeleteResponse;
+use OpenAI\Responses\Threads\ThreadResponse;
+
+class RawService
+{
+    use WaitsForThreadRunCompletion;
+
+    public function __construct(public Client $client)
+    {
+        //
+    }
+
+    public function createThreadAsRaw(string $subject): ThreadResponse
+    {
+        $remoteThread = $this->client->threads()->create([
+            'messages' => [
+                [
+                    'role' => 'user',
+                    'content' => $subject,
+                ],
+            ],
+        ]);
+
+        $run = $this->client->threads()->runs()->create($remoteThread->id, [
+            'assistant_id' => config('chatbot.assistant_id'),
+        ]);
+
+        $this->waitForThreadRunCompletion($remoteThread->id, $run->id);
+
+        return $this->client->threads()->retrieve($remoteThread->id);
+    }
+
+    public function threadAsRaw(string $threadId): ThreadResponse
+    {
+        return $this->client->threads()->retrieve($threadId);
+    }
+
+    public function listThreadMessagesAsRaw(string $remoteThreadId): ThreadMessageListResponse
+    {
+        return $this->client->threads()->messages()->list($remoteThreadId);
+    }
+
+    public function messageAsRaw($threadId, $messageId): ThreadMessageResponse
+    {
+        return $this->client->threads()->messages()->retrieve($threadId, $messageId);
+    }
+
+    public function modifyMessageAsRaw(string $threadId, string $messageId, array $parameters): ThreadMessageResponse
+    {
+        return $this->client->threads()->messages()->modify($threadId, $messageId, $parameters);
+    }
+
+    public function updateThreadAsRaw(string $remoteThreadId, array $data): ThreadResponse
+    {
+        $this->client->threads()->messages()->create($remoteThreadId, $data);
+
+        $run = $this->client->threads()->runs()->create($remoteThreadId, [
+            'assistant_id' => config('chatbot.assistant_id'),
+        ]);
+
+        $this->waitForThreadRunCompletion($remoteThreadId, $run->id);
+
+        return $this->client->threads()->retrieve($remoteThreadId);
+    }
+
+    public function deleteThreadAsRaw(string $remoteThreadId): ThreadDeleteResponse
+    {
+        return $this->client->threads()->delete($remoteThreadId);
+    }
+}

--- a/src/Traits/WaitsForThreadRunCompletion.php
+++ b/src/Traits/WaitsForThreadRunCompletion.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace HalilCosdu\ChatBot\Traits;
+
+use Illuminate\Support\Sleep;
+
+trait WaitsForThreadRunCompletion
+{
+    public function waitForThreadRunCompletion($remoteThreadId, $runId): void
+    {
+        do {
+            Sleep::sleep(config('chatbot.sleep_seconds', .1));
+
+            $run = $this->client->threads()->runs()->retrieve($remoteThreadId, $runId);
+        } while ($run->status !== 'completed');
+    }
+}

--- a/tests/ChatBotTest.php
+++ b/tests/ChatBotTest.php
@@ -2,12 +2,15 @@
 
 use HalilCosdu\ChatBot\ChatBot;
 use HalilCosdu\ChatBot\Services\ChatBotService;
+use HalilCosdu\ChatBot\Services\OpenAI\RawService;
 
 beforeEach(function () {
     $chatBotService = Mockery::mock(ChatBotService::class);
-    $chatBot = new ChatBot($chatBotService);
+    $rawService = Mockery::mock(RawService::class);
+    $chatBot = new ChatBot($chatBotService, $rawService);
 
     $this->chatBotService = $chatBotService;
+    $this->rawService = $rawService;
     $this->chatBot = $chatBot;
 });
 


### PR DESCRIPTION
### Raw Data - Not Saved to Database
#### You can use the following methods to interact with the OpenAI API directly.

```php
public function createThreadAsRaw(string $subject)
public function listThreadMessagesAsRaw(string $remoteThreadId)
public function updateThreadAsRaw(string $remoteThreadId, array $data) /* $data = ['role' => 'user or assistant', 'content' => 'Hello'] */
public function deleteThreadAsRaw(string $remoteThreadId)
public function threadAsRaw(string $threadId)
public function messageAsRaw(string $threadId, string $messageId)
public function modifyMessageAsRaw(string $threadId, string $messageId, array $parameters)
```

```php
ChatBot::createThreadAsRaw(string $subject);
ChatBot::listThreadMessagesAsRaw(string $remoteThreadId);
ChatBot::updateThreadAsRaw(string $remoteThreadId, array $data);
ChatBot::deleteThreadAsRaw(string $remoteThreadId);
ChatBot::threadAsRaw(string $threadId);
ChatBot::messageAsRaw(string $threadId, string $messageId);
ChatBot::modifyMessageAsRaw(string $threadId, string $messageId, array $parameters);
```