### PR TITLE
Update model property type

### DIFF
--- a/src/Services/ChatBotService.php
+++ b/src/Services/ChatBotService.php
@@ -14,7 +14,7 @@ class ChatBotService
 {
     use WaitsForThreadRunCompletion;
 
-    protected ?Model $model = null;
+    protected string $model;
 
     public function __construct(public Client $client)
     {


### PR DESCRIPTION
The `model` property is not an instance of `Model`, both the config file and this line return string

`HalilCosdu\ChatBot\Models\Thread::class`

Which causes this error:

`Cannot assign string to property HalilCosdu\ChatBot\Services\ChatBotService::$model of type ?Illuminate\Database\Eloquent\Model`

This PR fixes it.