### PR TITLE
Switch from legacy to latest version of Assistants

### DIFF
--- a/src/ChatBotServiceProvider.php
+++ b/src/ChatBotServiceProvider.php
@@ -55,7 +55,7 @@ class ChatBotServiceProvider extends PackageServiceProvider
                 $openAI = OpenAIFactory::factory()
                     ->withApiKey($apiKey)
                     ->withOrganization($organization)
-                    ->withHttpHeader('OpenAI-Beta', 'assistants=v1')
+                    ->withHttpHeader('OpenAI-Beta', 'assistants=v2')
                     ->withHttpClient(new \GuzzleHttp\Client(['timeout' => config('chatbot.request_timeout', 30)]))
                     ->make();
 

--- a/src/Services/ChatBotService.php
+++ b/src/Services/ChatBotService.php
@@ -14,7 +14,7 @@ class ChatBotService
 {
     use WaitsForThreadRunCompletion;
 
-    protected ?Model $model = null;
+    protected string $model;
 
     public function __construct(public Client $client)
     {


### PR DESCRIPTION
Switching from legacy version to the latest version.

Can we please tag a new release? 

![image](https://github.com/halilcosdu/laravel-chatbot/assets/36804104/b5ffe90d-d1bf-4cdb-9b08-8f9709ea5d21)
