### PR TITLE
v1.3.1 — last Assistants maintenance (infinite-loop fix + deprecation banner)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2.4.0
+        uses: dependabot/fetch-metadata@v3.0.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
 
@@ -23,6 +23,6 @@ jobs:
         uses: aglipanci/laravel-pint-action@2.6
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: Fix styling

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Make 30 commits
       run: |
@@ -28,6 +28,6 @@ jobs:
         done
 
     - name: Push changes
-      uses: ad-m/github-push-action@v0.8.0
+      uses: ad-m/github-push-action@v1.0.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest ]
-        php: [ 8.3, 8.2 ]
+        php: [ 8.4, 8.3, 8.2 ]
         laravel: [ 11.*, 12.*, 13.* ]
         stability: [ prefer-lowest, prefer-stable ]
         include:
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
 
@@ -25,7 +25,7 @@ jobs:
           release-notes: ${{ github.event.release.body }}
 
       - name: Commit updated CHANGELOG
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           branch: main
           commit_message: Update CHANGELOG

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to `laravel-chatbot` will be documented in this file.
 
+## v1.3.1 - 2026-07-03
+
+> **Maintenance-only release.** The 1.x line is built on the OpenAI Assistants API, which shuts down on **2026-08-26**. A **2.0** migration to the Responses + Conversations API is in development (target stable 2026-08-12). Until then, 1.x receives only critical fixes.
+
+### Fixed
+- **`WaitsForThreadRunCompletion` no longer loops forever.** The run poller is now bounded by `run_max_attempts` (default 600) and throws `HalilCosdu\ChatBot\Exceptions\ThreadRunException` on terminal failure statuses (`failed`, `cancelled`, `expired`, `incomplete`), on `requires_action` (unsupported — tool-output submission is out of scope), and on timeout. Previously a run that never reached `completed` would poll indefinitely.
+
+### Changed
+- **CI** now tests PHP 8.4 (matrix: 8.2/8.3/8.4 × Laravel 11/12/13). Note: `openai-php/laravel` does not support Laravel 10, so Laravel 10 is not in the matrix despite the broad `illuminate/contracts` constraint.
+- Bumped GitHub Actions: `actions/checkout` v6, `stefanzweifel/git-auto-commit-action` v7, `dependabot/fetch-metadata` v3.0.0, `ad-m/github-push-action` v1.0.0. Supersedes dependabot #36, #38, #40, #41. The `openai-php/laravel` bump (#39) is deferred to v2.
+- **PHPStan was broken** by an invalid `checkMissingIterableValueType` option; removed and baseline regenerated.
+- `ChatBotService` and `RawService` now type-hint `OpenAI\Contracts\ClientContract` instead of the final concrete `Client`, so they can be substituted/faked in tests.
+
+### Added
+- Test coverage for `WaitsForThreadRunCompletion` (completed / terminal failure / `requires_action` / timeout / continued polling). 8 → 13 tests.
+- New config key `run_max_attempts` (default 600).
+
+### Documentation
+- README: prominent deprecation banner pointing at the 2026-08-26 shutdown and the upcoming v2.
+
 ## v1.3.0 - 2026-04-09
 
 ### What's Changed

--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@
 [![GitHub Code Style Action Status](https://img.shields.io/github/actions/workflow/status/halilcosdu/laravel-chatbot/fix-php-code-style-issues.yml?branch=main&label=code%20style&style=flat-square)](https://github.com/halilcosdu/laravel-chatbot/actions?query=workflow%3A"Fix+PHP+code+style+issues"+branch%3Amain)
 [![Total Downloads](https://img.shields.io/packagist/dt/halilcosdu/laravel-chatbot.svg?style=flat-square)](https://packagist.org/packages/halilcosdu/laravel-chatbot)
 
+> ⚠️ **Deprecation notice — OpenAI Assistants API shutdown on 2026-08-26**
+>
+> This package is built on the **OpenAI Assistants API**, which OpenAI deprecated on 2025-08-20 and will **shut down on 2026-08-26**. After that date, the 1.x line of this package will stop working.
+>
+> - A **2.0 release** that migrates to the OpenAI **Responses + Conversations API** is in development, with a stable target of **2026-08-12** (two weeks before shutdown).
+> - Until 2.0 lands, the 1.x line is in **maintenance-only** mode: this release fixes an infinite-loop bug and adds test coverage, but does not add features.
+> - If you are starting a new project, consider waiting for 2.0 or use the Responses API directly.
+
 Laravel Chatbot provides a robust and easy-to-use solution for integrating AI chatbots into your Laravel applications. Leveraging the power of OpenAI, it allows you to create, manage, and interact with chat threads directly from your Laravel application. Whether you're building a customer service chatbot or an interactive AI assistant, `laravel-chatbot` offers a streamlined, Laravel-friendly interface to the OpenAI API.
 ## Installation
 

--- a/config/chatbot.php
+++ b/config/chatbot.php
@@ -11,6 +11,7 @@ return [
     'organization' => env('OPENAI_ORGANIZATION'),
     'request_timeout' => env('OPENAI_TIMEOUT'),
     'sleep_seconds' => env('OPENAI_SLEEP_SECONDS'),
+    'run_max_attempts' => env('OPENAI_RUN_MAX_ATTEMPTS', 600),
     'models' => [
         'thread' => env('CHATBOT_THREAD_MODEL', Thread::class),
         'thread_messages' => env('CHATBOT_THREAD_MESSAGE_MODEL', ThreadMessage::class),

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,7 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
+			identifier: larastan.noEnvCallsOutsideOfConfig
+			count: 8
+			path: config/chatbot.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,5 +10,4 @@ parameters:
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
-    checkMissingIterableValueType: false
 

--- a/src/ChatBotServiceProvider.php
+++ b/src/ChatBotServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace HalilCosdu\ChatBot;
 
+use GuzzleHttp\Client;
 use HalilCosdu\ChatBot\Services\ChatBotService;
 use HalilCosdu\ChatBot\Services\OpenAI\RawService;
 use InvalidArgumentException;
@@ -56,7 +57,7 @@ class ChatBotServiceProvider extends PackageServiceProvider
                     ->withApiKey($apiKey)
                     ->withOrganization($organization)
                     ->withHttpHeader('OpenAI-Beta', 'assistants=v2')
-                    ->withHttpClient(new \GuzzleHttp\Client(['timeout' => config('chatbot.request_timeout', 30)]))
+                    ->withHttpClient(new Client(['timeout' => config('chatbot.request_timeout', 30)]))
                     ->make();
 
                 return new $service($openAI);

--- a/src/Exceptions/ThreadRunException.php
+++ b/src/Exceptions/ThreadRunException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace HalilCosdu\ChatBot\Exceptions;
+
+use RuntimeException;
+
+class ThreadRunException extends RuntimeException {}

--- a/src/Services/ChatBotService.php
+++ b/src/Services/ChatBotService.php
@@ -8,7 +8,7 @@ use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
-use OpenAI\Client;
+use OpenAI\Contracts\ClientContract;
 
 class ChatBotService
 {
@@ -16,7 +16,7 @@ class ChatBotService
 
     protected string $model;
 
-    public function __construct(public Client $client)
+    public function __construct(public ClientContract $client)
     {
         $this->model = config('chatbot.models.thread', Thread::class);
     }

--- a/src/Services/OpenAI/RawService.php
+++ b/src/Services/OpenAI/RawService.php
@@ -3,7 +3,7 @@
 namespace HalilCosdu\ChatBot\Services\OpenAI;
 
 use HalilCosdu\ChatBot\Traits\WaitsForThreadRunCompletion;
-use OpenAI\Client;
+use OpenAI\Contracts\ClientContract;
 use OpenAI\Responses\Threads\Messages\ThreadMessageListResponse;
 use OpenAI\Responses\Threads\Messages\ThreadMessageResponse;
 use OpenAI\Responses\Threads\ThreadDeleteResponse;
@@ -13,7 +13,7 @@ class RawService
 {
     use WaitsForThreadRunCompletion;
 
-    public function __construct(public Client $client)
+    public function __construct(public ClientContract $client)
     {
         //
     }

--- a/src/Traits/WaitsForThreadRunCompletion.php
+++ b/src/Traits/WaitsForThreadRunCompletion.php
@@ -2,16 +2,58 @@
 
 namespace HalilCosdu\ChatBot\Traits;
 
+use HalilCosdu\ChatBot\Exceptions\ThreadRunException;
 use Illuminate\Support\Sleep;
 
 trait WaitsForThreadRunCompletion
 {
-    public function waitForThreadRunCompletion($remoteThreadId, $runId): void
+    /**
+     * Poll a thread run until it reaches a terminal state.
+     *
+     * Status handling (per the OpenAI Assistants API):
+     *  - `completed`: success, returns.
+     *  - `failed`, `cancelled`, `expired`, `incomplete`: terminal failures, throw.
+     *  - `requires_action`: unsupported here (no tool-output submission), throw.
+     *  - `queued`, `in_progress`, `cancelling`: keep polling.
+     *
+     * @param  int|null  $maxAttempts  Override the configured maximum poll attempts.
+     *
+     * @throws ThreadRunException when the run fails, needs action, or does not finish in time.
+     */
+    public function waitForThreadRunCompletion($remoteThreadId, $runId, ?int $maxAttempts = null): void
     {
-        do {
-            Sleep::sleep(config('chatbot.sleep_seconds', .1));
+        $maxAttempts ??= (int) config('chatbot.run_max_attempts', 600);
+        $sleepSeconds = (float) config('chatbot.sleep_seconds', 0.1);
 
-            $run = $this->client->threads()->runs()->retrieve($remoteThreadId, $runId);
-        } while ($run->status !== 'completed');
+        $terminalFailures = ['failed', 'cancelled', 'expired', 'incomplete'];
+
+        for ($attempt = 0; $attempt < $maxAttempts; $attempt++) {
+            Sleep::sleep($sleepSeconds);
+
+            $run = $this->retrieveRun($remoteThreadId, $runId);
+
+            if ($run->status === 'completed') {
+                return;
+            }
+
+            if (in_array($run->status, $terminalFailures, true)) {
+                throw new ThreadRunException("Thread run [{$runId}] ended with terminal status [{$run->status}].");
+            }
+
+            if ($run->status === 'requires_action') {
+                throw new ThreadRunException("Thread run [{$runId}] requires action; tool-output submission is not supported by this package.");
+            }
+        }
+
+        throw new ThreadRunException("Thread run [{$runId}] did not complete within {$maxAttempts} attempts.");
+    }
+
+    /**
+     * Fetch the current run state. Extracted so tests can override without
+     * having to mock the openai-php client chain.
+     */
+    protected function retrieveRun(string $remoteThreadId, string $runId): object
+    {
+        return $this->client->threads()->runs()->retrieve($remoteThreadId, $runId);
     }
 }

--- a/tests/ChatBotTest.php
+++ b/tests/ChatBotTest.php
@@ -11,7 +11,7 @@ beforeEach(function () {
     $rawService = mock(RawService::class);
     $chatBot = new ChatBot($chatBotService, $rawService);
     $className = config('chatbot.models.thread', Thread::class);
-    $mockedThread = new $className();
+    $mockedThread = new $className;
 
     $this->chatBotService = $chatBotService;
     $this->rawService = $rawService;

--- a/tests/WaitsForThreadRunCompletionTest.php
+++ b/tests/WaitsForThreadRunCompletionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use HalilCosdu\ChatBot\Exceptions\ThreadRunException;
+use HalilCosdu\ChatBot\Traits\WaitsForThreadRunCompletion;
+use Illuminate\Support\Sleep;
+
+function makeTester(array $statuses): object
+{
+    return new class($statuses)
+    {
+        use WaitsForThreadRunCompletion;
+
+        public function __construct(private array $statuses) {}
+
+        protected function retrieveRun(string $remoteThreadId, string $runId): object
+        {
+            $status = array_shift($this->statuses) ?? 'in_progress';
+
+            return new class($status)
+            {
+                public function __construct(public string $status) {}
+            };
+        }
+    };
+}
+
+beforeEach(function () {
+    Sleep::fake();
+    config(['chatbot.sleep_seconds' => 0]);
+});
+
+it('returns when the run completes', function () {
+    makeTester(['completed'])->waitForThreadRunCompletion('thread_1', 'run_1', 5);
+
+    expect(true)->toBeTrue();
+});
+
+it('throws when the run reaches a terminal failure status', function ($status) {
+    makeTester([$status])->waitForThreadRunCompletion('thread_1', 'run_1', 5);
+})->throws(ThreadRunException::class)->with(['failed', 'cancelled', 'expired', 'incomplete']);
+
+it('throws when the run requires action', function () {
+    makeTester(['requires_action'])->waitForThreadRunCompletion('thread_1', 'run_1', 5);
+})->throws(ThreadRunException::class);
+
+it('throws a timeout exception when the run never finishes', function () {
+    makeTester(['in_progress'])->waitForThreadRunCompletion('thread_1', 'run_1', 3);
+})->throws(ThreadRunException::class);
+
+it('keeps polling while in_progress and returns once completed', function () {
+    makeTester(['in_progress', 'in_progress', 'completed'])->waitForThreadRunCompletion('thread_1', 'run_1', 5);
+
+    expect(true)->toBeTrue();
+});


### PR DESCRIPTION
Maintenance-only release of the 1.x line. The 1.x line is built on the **OpenAI Assistants API**, which shuts down on **2026-08-26**; a **v2.0** migration to the Responses + Conversations API is in development (target stable 2026-08-12). This PR buys time and stops a real production footgun.

## Fixed
- **`WaitsForThreadRunCompletion` no longer loops forever.** The run poller is now bounded by `run_max_attempts` (default 600) and throws `HalilCosdu\ChatBot\Exceptions\ThreadRunException` on terminal failure statuses (`failed`, `cancelled`, `expired`, `incomplete`), on `requires_action` (unsupported — tool-output submission is out of scope), and on timeout.

## Changed
- **CI** now tests PHP 8.4. Note: Laravel 10 is intentionally **not** in the matrix — `openai-php/laravel` does not support it (this corrects the misleading `illuminate/contracts ^10` claim).
- Bumped actions: `checkout` v6, `git-auto-commit-action` v7, `fetch-metadata` v3.0.0, `github-push-action` v1.0.0. Supersedes #36, #38, #40, #41. The `openai-php/laravel` bump (#39) is **deferred to v2** (it changes framework support).
- **PHPStan was broken** by an invalid `checkMissingIterableValueType` option; removed + baseline regenerated.
- `ChatBotService` and `RawService` now type-hint `OpenAI\Contracts\ClientContract` (the concrete `Client` is `final`), so they can be faked in tests.

## Added
- Test coverage for `WaitsForThreadRunCompletion` (completed / terminal failure / `requires_action` / timeout / continued polling). 8 → 13 tests.
- New config key `run_max_attempts` (default 600) and `ThreadRunException`.

## Documentation
- README: prominent deprecation banner pointing at the 2026-08-26 shutdown and the upcoming v2.

## Verification (local)
- [x] `composer test` — 13 passed
- [x] `vendor/bin/phpstan analyse` — clean
- [x] `composer format` — clean

> CI will likely show as failing due to the account-level Actions billing lock; the code side is green locally.

## Next: v2.0.0
Full Responses + Conversations API migration (ChatBotService + RawService rewrite, `assistant_id` → `prompt_id`/model config, `remote_conversation_id` migration, local-history → Conversation migration command, upgrade guide, full ClientFake tests). Target stable 2026-08-12.