### PR TITLE
v2.0.1 — ChatBotService + RawService ClientFake test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `laravel-chatbot` will be documented in this file.
 
+## v2.0.1 - 2026-07-03
+
+### Added
+- **Service-layer test coverage** deferred from v2.0.0. `Http`/openai `ClientFake` + `Response::from` fixture-backed tests for `ChatBotService` (create / update / delete / failure paths / unmigrated-thread guard) and `RawService` (conversation create/retrieve/delete + response create). Suite: 8 → 17 tests.
+
 ## v2.0.0 - 2026-07-03
 
 The 2.x line migrates from the **OpenAI Assistants API** (shut down on **2026-08-26**) to the **Responses + Conversations API**. This is a breaking change. See [UPGRADE.md](UPGRADE.md).

--- a/tests/ChatBotServiceTest.php
+++ b/tests/ChatBotServiceTest.php
@@ -1,0 +1,129 @@
+<?php
+
+use HalilCosdu\ChatBot\Exceptions\ChatBotException;
+use HalilCosdu\ChatBot\Models\Thread;
+use HalilCosdu\ChatBot\Models\ThreadMessage;
+use HalilCosdu\ChatBot\Services\ChatBotService;
+use OpenAI\Responses\Conversations\ConversationDeletedResponse;
+use OpenAI\Responses\Conversations\ConversationResponse;
+use OpenAI\Responses\Meta\MetaInformation;
+use OpenAI\Responses\Responses\CreateResponse;
+use OpenAI\Testing\ClientFake;
+
+function meta(): MetaInformation
+{
+    return MetaInformation::from(['x-request-id' => ['req-1']]);
+}
+
+function fakeConversation(string $id = 'conv_1'): ConversationResponse
+{
+    return ConversationResponse::from([
+        'id' => $id,
+        'object' => 'conversation',
+        'created_at' => 1,
+        'metadata' => [],
+    ], meta());
+}
+
+function fakeDeletedConversation(): ConversationDeletedResponse
+{
+    return ConversationDeletedResponse::from([
+        'id' => 'conv_del',
+        'object' => 'conversation.deleted',
+        'deleted' => true,
+    ], meta());
+}
+
+function fakeResponse(string $text, string $status = 'completed'): CreateResponse
+{
+    return CreateResponse::from([
+        'id' => 'resp_1',
+        'object' => 'response',
+        'created_at' => 1,
+        'status' => $status,
+        'model' => 'gpt-5.4-mini',
+        'output' => [
+            ['id' => 'msg_1', 'type' => 'message', 'role' => 'assistant', 'status' => 'completed',
+                'content' => [['type' => 'output_text', 'text' => $text, 'annotations' => []]]],
+        ],
+        'output_text' => $text,
+        'error' => null,
+        'instructions' => null,
+        'background' => false,
+        'parallel_tool_calls' => false,
+        'previous_response_id' => null,
+        'temperature' => 1.0,
+        'tool_choice' => 'auto',
+        'tools' => [],
+        'top_p' => 1.0,
+        'max_output_tokens' => null,
+        'max_tool_calls' => null,
+        'prompt' => null,
+        'user' => null,
+        'service_tier' => 'auto',
+        'metadata' => [],
+        'incomplete_details' => null,
+        'reasoning' => null,
+        'text' => null,
+        'truncation' => 'disabled',
+        'usage' => null,
+        'store' => true,
+        'top_logprobs' => null,
+    ], meta());
+}
+
+describe('create', function () {
+    it('creates a conversation, runs a response, and stores user + assistant messages', function () {
+        $client = new ClientFake([fakeConversation('conv_1'), fakeResponse('Hello!')]);
+        $service = new ChatBotService($client);
+
+        $thread = $service->create('Why is the sky blue?', ownerId: 7);
+
+        expect($thread->remote_conversation_id)->toBe('conv_1')
+            ->and($thread->subject)->toBe('Why is the sky blue?');
+
+        expect($thread->threadMessages)->toHaveCount(2);
+        expect(ThreadMessage::where('role', 'user')->first()->content)->toBe('Why is the sky blue?');
+        expect(ThreadMessage::where('role', 'assistant')->first()->content)->toBe('Hello!');
+    });
+
+    it('throws when the response is not completed', function () {
+        $client = new ClientFake([fakeConversation(), fakeResponse('x', status: 'failed')]);
+        $service = new ChatBotService($client);
+
+        $service->create('hi');
+    })->throws(ChatBotException::class);
+});
+
+describe('update', function () {
+    it('continues a migrated thread with a new response', function () {
+        $thread = Thread::factory()->create(['remote_conversation_id' => 'conv_existing']);
+        $client = new ClientFake([fakeResponse('Reply!')]);
+        $service = new ChatBotService($client);
+
+        $assistantMessage = $service->update('follow up?', $thread->id);
+
+        expect($assistantMessage->role)->toBe('assistant')
+            ->and($assistantMessage->content)->toBe('Reply!');
+        expect(ThreadMessage::where('role', 'user')->latest('id')->first()->content)->toBe('follow up?');
+    });
+
+    it('throws a helpful error when the thread has not been migrated', function () {
+        $thread = Thread::factory()->create(['remote_conversation_id' => null]);
+        $service = new ChatBotService(new ClientFake([]));
+
+        $service->update('hi', $thread->id);
+    })->throws(ChatBotException::class);
+});
+
+describe('delete', function () {
+    it('deletes the remote conversation and the local thread', function () {
+        $thread = Thread::factory()->create(['remote_conversation_id' => 'conv_del']);
+        $client = new ClientFake([fakeDeletedConversation()]);
+        $service = new ChatBotService($client);
+
+        $service->delete($thread->id);
+
+        expect(Thread::find($thread->id))->toBeNull();
+    });
+});

--- a/tests/RawServiceTest.php
+++ b/tests/RawServiceTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use HalilCosdu\ChatBot\Services\OpenAI\RawService;
+use OpenAI\Responses\Conversations\ConversationDeletedResponse;
+use OpenAI\Responses\Conversations\ConversationResponse;
+use OpenAI\Responses\Meta\MetaInformation;
+use OpenAI\Responses\Responses\CreateResponse;
+use OpenAI\Testing\ClientFake;
+
+function rawMeta(): MetaInformation
+{
+    return MetaInformation::from(['x-request-id' => ['req-1']]);
+}
+
+function rawConversation(string $id = 'conv_raw')
+{
+    return ConversationResponse::from([
+        'id' => $id, 'object' => 'conversation', 'created_at' => 1, 'metadata' => [],
+    ], rawMeta());
+}
+
+function rawDeleted(): ConversationDeletedResponse
+{
+    return ConversationDeletedResponse::from([
+        'id' => 'conv_del', 'object' => 'conversation.deleted', 'deleted' => true,
+    ], rawMeta());
+}
+
+function rawResponse(string $text = 'out'): CreateResponse
+{
+    return CreateResponse::from([
+        'id' => 'resp_raw', 'object' => 'response', 'created_at' => 1, 'status' => 'completed',
+        'model' => 'gpt', 'output' => [['id' => 'm', 'type' => 'message', 'role' => 'assistant', 'status' => 'completed',
+            'content' => [['type' => 'output_text', 'text' => $text, 'annotations' => []]]]],
+        'output_text' => $text, 'error' => null, 'instructions' => null, 'background' => false,
+        'parallel_tool_calls' => false, 'previous_response_id' => null, 'temperature' => 1.0,
+        'tool_choice' => 'auto', 'tools' => [], 'top_p' => 1.0, 'max_output_tokens' => null,
+        'max_tool_calls' => null, 'prompt' => null, 'user' => null, 'service_tier' => 'auto',
+        'metadata' => [], 'incomplete_details' => null, 'reasoning' => null, 'text' => null,
+        'truncation' => 'disabled', 'usage' => null, 'store' => true, 'top_logprobs' => null,
+    ], rawMeta());
+}
+
+it('creates a conversation via raw', function () {
+    $service = new RawService(new ClientFake([rawConversation('conv_new')]));
+
+    expect($service->createConversationAsRaw()->id)->toBe('conv_new');
+});
+
+it('retrieves a conversation via raw', function () {
+    $service = new RawService(new ClientFake([rawConversation('conv_get')]));
+
+    expect($service->conversationAsRaw('conv_get')->id)->toBe('conv_get');
+});
+
+it('deletes a conversation via raw', function () {
+    $service = new RawService(new ClientFake([rawDeleted()]));
+
+    expect($service->deleteConversationAsRaw('conv_del')->deleted)->toBeTrue();
+});
+
+it('creates a response via raw', function () {
+    $service = new RawService(new ClientFake([rawResponse('answer')]));
+
+    expect($service->createResponseAsRaw(['input' => []])->outputText)->toBe('answer');
+});


### PR DESCRIPTION
Backfills the service-layer tests deferred from v2.0.0. Test-only patch — no functional changes.

## Added
- **ChatBotService** (5 tests via `OpenAI\Testing\ClientFake` + `Response::from` fixtures):
  - `create()` — creates conversation, runs response, stores user + assistant messages
  - `create()` failure — throws `ChatBotException` on non-completed response
  - `update()` — continues a migrated thread with a new response
  - `update()` guard — throws with a "run chatbot:migrate-to-conversations" hint when `remote_conversation_id` is null
  - `delete()` — deletes the remote conversation and the local thread
- **RawService** (4 tests): conversation create/retrieve/delete + response create

Suite: 8 → 17 tests.

## Verification (local)
- [x] `composer test` — 17 passed
- [x] `vendor/bin/phpstan analyse` — clean
- [x] `composer format` — clean

> CI will likely show as failing due to the account-level Actions billing lock; the code side is green locally.